### PR TITLE
Fix: Remove esphome-docs pip install step after Hugo migration

### DIFF
--- a/.github/workflows/generate-schemas.yml
+++ b/.github/workflows/generate-schemas.yml
@@ -61,10 +61,6 @@ jobs:
           ref: ${{ contains(needs.information.outputs.version, 'dev') && 'next' || needs.information.outputs.version }}
           fetch-depth: 1
 
-      - name: Install ESPHome docs dependencies
-        working-directory: esphome-docs
-        run: pip install -r requirements.txt
-
       - name: Add docs to language schema
         working-directory: esphome-docs
         run: |


### PR DESCRIPTION
## Problem
The GitHub workflow has been broken for months because esphome-docs migrated from Sphinx to Hugo and no longer has a `requirements.txt` file.

Error:
```
ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'requirements.txt'
```

## Root Cause
- `esphome/esphome-docs` migrated to Hugo (~August/September 2025)
- No longer uses Sphinx, so no `requirements.txt` exists
- The workflow still tried to `pip install -r requirements.txt` in the esphome-docs directory

## Solution
Removed the "Install ESPHome docs dependencies" step entirely since:
- `script/schema_doc.py` only uses Python standard library (no external deps)
- The script works fine without any pip packages

## Impact
This unblocks schema generation for the VSCode plugin and other consumers.