### PR TITLE
Add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
## Summary

Add a `.github/dependabot.yml` that tracks the `github-actions` ecosystem on a daily schedule, so the workflow's pinned action SHAs stay current as new releases ship.