### PR TITLE
Check out the esphome.io release branch instead of the version tag

### DIFF
--- a/.github/workflows/generate-schemas.yml
+++ b/.github/workflows/generate-schemas.yml
@@ -53,12 +53,32 @@ jobs:
       - name: Generate language schema
         run: python esphome/script/build_language_schema.py --output-path=./schema
 
+      - name: Resolve esphome.io ref
+        id: docs-ref
+        # The docs tag is pushed separately from the esphome release and can
+        # lag it; fall back to the release branch when the tag isn't there yet.
+        env:
+          VERSION: ${{ needs.information.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ "$VERSION" == *dev* ]]; then
+            ref="next"
+          elif git ls-remote --exit-code https://github.com/esphome/esphome.io "refs/tags/$VERSION" >/dev/null; then
+            ref="$VERSION"
+          elif [[ "$VERSION" == *b* ]]; then
+            ref="beta"
+          else
+            ref="current"
+          fi
+          echo "Using esphome.io ref: $ref"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
       - name: Checkout esphome.io repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           repository: esphome/esphome.io
           path: esphome.io
-          ref: ${{ contains(needs.information.outputs.version, 'dev') && 'next' || needs.information.outputs.version }}
+          ref: ${{ steps.docs-ref.outputs.ref }}
           fetch-depth: 1
 
       - name: Add docs to language schema

--- a/.github/workflows/generate-schemas.yml
+++ b/.github/workflows/generate-schemas.yml
@@ -53,32 +53,15 @@ jobs:
       - name: Generate language schema
         run: python esphome/script/build_language_schema.py --output-path=./schema
 
-      - name: Resolve esphome.io ref
-        id: docs-ref
-        # The docs tag is pushed separately from the esphome release and can
-        # lag it; fall back to the release branch when the tag isn't there yet.
-        env:
-          VERSION: ${{ needs.information.outputs.version }}
-        run: |
-          set -euo pipefail
-          if [[ "$VERSION" == *dev* ]]; then
-            ref="next"
-          elif git ls-remote --exit-code https://github.com/esphome/esphome.io "refs/tags/$VERSION" >/dev/null; then
-            ref="$VERSION"
-          elif [[ "$VERSION" == *b* ]]; then
-            ref="beta"
-          else
-            ref="current"
-          fi
-          echo "Using esphome.io ref: $ref"
-          echo "ref=$ref" >> "$GITHUB_OUTPUT"
-
       - name: Checkout esphome.io repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           repository: esphome/esphome.io
           path: esphome.io
-          ref: ${{ steps.docs-ref.outputs.ref }}
+          # The docs tag is pushed separately from the esphome release and can
+          # lag it; the release branch gets the version bump before this
+          # workflow runs, so check out the branch instead of the tag.
+          ref: ${{ contains(needs.information.outputs.version, 'dev') && 'next' || (contains(needs.information.outputs.version, 'b') && 'beta' || 'current') }}
           fetch-depth: 1
 
       - name: Add docs to language schema


### PR DESCRIPTION
The 2026.8.0b3 schema build failed because the esphome.io tag was not pushed yet when the workflow checked it out; the tag is pushed separately from the esphome release, so it can lag by an unbounded amount, and b1/b2 only worked by timing.

This checks out the release branch instead of the tag; the version bump merges to beta or current before this workflow runs, so the branch has the same content the tag would, and dev keeps using next as before. The branch names are picked by a pure expression, so no runtime value flows into the checkout ref.
